### PR TITLE
Add SQL migrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val fs2Version = "3.11.0"
 val http4sVersion = "0.23.30"
 val cirisVersion = "3.7.0"
 val skunkVersion = "1.0.0-M10"
+val dumboVersion = "0.5.5"
 
 // Global settings.
 ThisBuild / scalaVersion := "3.3.5"
@@ -63,6 +64,7 @@ lazy val server =
         "is.cir" %% "ciris" % cirisVersion,
         "is.cir" %% "ciris-http4s" % cirisVersion,
         "org.tpolecat" %% "skunk-core" % skunkVersion,
+        "dev.rolang" %% "dumbo" % dumboVersion,
         "org.http4s" %% "http4s-server" % http4sVersion,
         "org.http4s" %% "http4s-ember-server" % http4sVersion
       )

--- a/modules/server/src/main/resources/db/migrations/V1__create_todos_table.sql
+++ b/modules/server/src/main/resources/db/migrations/V1__create_todos_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE todos(
+  todo_id UUID PRIMARY KEY,
+  reminder TEXT NOT NULL,
+  due_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  completion_time TIMESTAMP WITH TIME ZONE NULL
+)

--- a/modules/server/src/main/scala/pi2/cicd/TodoApp.scala
+++ b/modules/server/src/main/scala/pi2/cicd/TodoApp.scala
@@ -12,6 +12,7 @@ object TodoApp:
   ): Resource[IO, Server] =
     for
       skunkSession <- repository.SkunkSession.make(config = config.db)
+      _ <- repository.migrations.run(session = skunkSession).toResource
       todoRepository = repository.TodoRepository.make(session = skunkSession)
       todoService = service.todo.make(repository = todoRepository)
       server <- server.make(

--- a/modules/server/src/main/scala/pi2/cicd/repository/migrations.scala
+++ b/modules/server/src/main/scala/pi2/cicd/repository/migrations.scala
@@ -1,0 +1,24 @@
+package co.edu.eafit.dis.pi2.cicd
+package repository
+package migrations
+
+import cats.effect.IO
+import cats.effect.Resource
+import dumbo.Dumbo
+import skunk.Session
+
+def run(
+  session: Session[IO]
+): IO[Unit] =
+  Dumbo
+    .withResourcesIn[IO]("db/migrations")
+    .withSession(
+      sessionResource = Resource.pure(session),
+      validateOnMigrate = true
+    )
+    .runMigration
+    .flatMap { result =>
+      IO.println(
+        s"Migration completed with ${result.migrationsExecuted} migrations"
+      )
+    }


### PR DESCRIPTION
Run **SQL** migrations when starting the `TODO` service.
Using **Dumbo** which is compatible with **Flayway** but uses **Skunk** under the hood.