### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Base Docker image.
+FROM mcr.microsoft.com/openjdk/jdk:21-distroless
+
+# Copy the assembly JAR into the app directory.
+WORKDIR /home/app
+COPY modules/server/target/scala-3.3.5/todo-service.jar app.jar
+
+# Use the custom app user to run the application.
+USER app
+
+# RUN the application as the Docker entrypoint.
+CMD ["-server", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # CI / CD demo for Azure
 
 Demo showing how to use **Github Actions** to configure a `CI / CD` pipeline deploying a **Dockerized** **Scala** app to **Azure** using **Terraform**.
+
+-----
+
+### Docker note
+
+Note that for the sake of example, this project uses a `Dockerfile` and an assembly **JAR**.
+That was done mostly for simplicity and since it could be more easily extrapolated to other languages.<br>
+For real **Scala** apps, it is usually recommended to use [**sbt-native-packager**](https://github.com/sbt/sbt-native-packager) instead.


### PR DESCRIPTION
Simple **Docker** image that runs the `TODO` service.
Based on the [**Microsoft** build of the **OpenJDK**](https://learn.microsoft.com/en-us/java/openjdk/containers).